### PR TITLE
feature: validate public keys to avoid ending up with bad key objects

### DIFF
--- a/riemann_keys/hdkey.py
+++ b/riemann_keys/hdkey.py
@@ -282,6 +282,10 @@ class HDKey(Immutable):
         '''
         xpub_bytes = base58.decode(xpub)
         pubkey = xpub_bytes[45:78]
+        try:
+            simple.compress_pubkey(pubkey)
+        except Exception:
+            raise ValueError('Cannot parse public key')
 
         if xpub_bytes[0:4] == utils.VERSION_BYTES['mainnet']['public']:
             network = 'Bitcoin'
@@ -353,6 +357,10 @@ class HDKey(Immutable):
         Returns:
             (HDKey): the key object
         '''
+        try:
+            simple.compress_pubkey(pubkey)
+        except Exception:
+            raise ValueError('Cannot parse public key')
         return HDKey(
             key_dict=KeyDict(
                 path=None,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='riemann-keys',
-    version='0.1.1',
+    version='0.1.2',
     description=('Hierarchical deterministic wallet creation tool'),
     author=[
         "Harsha Goli",


### PR DESCRIPTION
you can get a bad key by calling `HDKey.from_pubkey()` using any non-pubkey byte string. This PR adds validation to prevent that